### PR TITLE
fix(sidebar) dpr not loading quick workaround

### DIFF
--- a/_dprhtml/js/prefload.js
+++ b/_dprhtml/js/prefload.js
@@ -375,5 +375,6 @@ saveSearchSettings : saveSearchSettings,
 loadSearchSettings : loadSearchSettings,
 saveDictionarySearchSettings : saveDictionarySearchSettings,
 loadDictionarySearchSettings : loadDictionarySearchSettings,
+searchSettingsKeyName : searchSettingsKeyName
 }
 })()

--- a/_dprhtml/js/web/xml_sidebar.js
+++ b/_dprhtml/js/web/xml_sidebar.js
@@ -88,6 +88,12 @@ var DPRXML = {
 
     var xmlDoc = await XML_Load.loadXMLFileAsync(nikbookhier, 0);
 
+    if (xmlDoc === null){
+      console.error('Error loading file', e)
+      DPR_Chrome.showErrorToast(`Data files for [${nikbookhier}] not found. More info: ${e.message}`);
+      return;
+    }
+
     var nik = nikaya;
 
     var meta = (depth > 0 ? $('#tsoPmeta').prop('selectedIndex') : 0);

--- a/_dprhtml/js/web/xml_sidebar.js
+++ b/_dprhtml/js/web/xml_sidebar.js
@@ -90,7 +90,7 @@ var DPRXML = {
 
     if (xmlDoc === null){
       console.error('Error loading file', e)
-      DPR_Chrome.showErrorToast(`Data files for [${nikbookhier}] not found. More info: ${e.message}`);
+      DPR_prefload_mod.saveSearchSettings(DPR_G.DPR_prefsinfo[DPR_prefload_mod.searchSettingsKeyName].defaultValue);
       return;
     }
 


### PR DESCRIPTION
Closes #307

The problem is be caused be `xmlDoc` object being `null` in `updateSearchHierarchy`.

Steps to reproduce the error: Manually search for the term _mahaaggikkhandho_ in _Byākaraṇa_. Select _m_, _a_ and _t_.
Refresh https://www.digitalpalireader.online/_dprhtml/index.html -> stopped working.

This is due to the fact that the broken search is saved in the Local Storage in the search settings object:
DPR.Prefsv2_searchSettingsv2:"{"type":0,"query":"mahāggikkhandho","MAT":"mat","set":"g","book":"1","part":1,"rx":false}"

As for now, I only provided this quick workaround returning from the `updateSearchHierarchy` in case of `null` and resetting the search settings. The root cause has not been resolved.