### PR TITLE
feat: add shift+m/a/t shortcuts

### DIFF
--- a/_dprhtml/index.html
+++ b/_dprhtml/index.html
@@ -445,9 +445,12 @@
               <tr><td>p</td><td>&nbsp;Display previous section</td></tr>
               <tr><td>n</td><td>&nbsp;Display next section</td></tr>
               <tr><td>c</td><td>&nbsp;Copy permalink to clipboard</td></tr>
-              <tr><td>m</td><td>&nbsp;Switch to section in Mūla</td></tr>
-              <tr><td>a</td><td>&nbsp;Switch to section in Aṭṭhakathā</td></tr>
-              <tr><td>t</td><td>&nbsp;Switch to section in Ṭīkā</td></tr>
+              <tr><td>m</td><td>&nbsp;Switch to section in Mūla (side by side)</td></tr>
+              <tr><td>a</td><td>&nbsp;Switch to section in Aṭṭhakathā (side by side)</td></tr>
+              <tr><td>t</td><td>&nbsp;Switch to section in Ṭīkā (side by side)</td></tr>
+              <tr><td>M</td><td>&nbsp;Switch to section in Mūla (same pane)</td></tr>
+              <tr><td>A</td><td>&nbsp;Switch to section in Aṭṭhakathā (same pane)</td></tr>
+              <tr><td>T</td><td>&nbsp;Switch to section in Ṭīkā (same pane)</td></tr>
               <tr><td>q</td><td>&nbsp;Enter quick reference (DN, MN, SN, & AN only)</td></tr>
               <tr><td>s</td><td>&nbsp;Send selected text to convertor</td></tr>
               <tr><td>e</td><td>&nbsp;Send selected text to textpad</td></tr>

--- a/_dprhtml/js/dprviewmodel.js
+++ b/_dprhtml/js/dprviewmodel.js
@@ -173,8 +173,8 @@ const dprCommandList = [
     execute: emptyFn,
     visible: false,
     isDynamic: true,
-    title: "Open relative section in Mūla side by side (Keyboard shortcut: m). Shift+click to open in same pane.",
-    matchKey: e => e.key === 'm',
+    title: "Open relative section in Mūla side by side (Keyboard shortcut: m). Shift+click to open in same pane (Keyboard shortcut: M).",
+    matchKey: e => e.key === 'm' || e.key === 'M',
     matchGesture: _ => false,
   },
   {
@@ -184,8 +184,8 @@ const dprCommandList = [
     execute: emptyFn,
     visible: false,
     isDynamic: true,
-    title: "Open relative section in Aṭṭhakathā side by side (Keyboard shortcut: a). Shift+click to open in same pane.",
-    matchKey: e => e.key === 'a',
+    title: "Open relative section in Aṭṭhakathā side by side (Keyboard shortcut: a). Shift+click to open in same pane (Keyboard shortcut: A).",
+    matchKey: e => e.key === 'a' || e.key === 'A',
     matchGesture: _ => false,
   },
   {
@@ -195,8 +195,8 @@ const dprCommandList = [
     execute: emptyFn,
     visible: false,
     isDynamic: true,
-    title: "Open relative section in Ṭīkā side by side (Keyboard shortcut: t). Shift+click to open in same pane.",
-    matchKey: e => e.key === 't',
+    title: "Open relative section in Ṭīkā side by side (Keyboard shortcut: t). Shift+click to open in same pane (Keyboard shortcut: T).",
+    matchKey: e => e.key === 't' || e.key === 'T',
     matchGesture: _ => false,
   },
   {


### PR DESCRIPTION
This PR enables the user to switch between the Mūla, Aṭṭhakathā, and Ṭīkā texts within the same pane by using `Shift+M`, `Shift+A`, or `Shift+T` (respectively).

Closes #304.