### PR TITLE
fix: standardize mat tooltip

### DIFF
--- a/_dprhtml/js/xml.js
+++ b/_dprhtml/js/xml.js
@@ -228,7 +228,7 @@ async function loadXMLSection(sectionId, querystring,para,place,isPL)
           shortcutFns[cmds[hi[ht]]] = {
             canExecuteStr: 'true',
             executeStr: `DPR1_send_mod.openPlaceMATContextMenu(${sectionId}, ['${place[0]}', ${place[1]}, ${place[2]}, ${place[3]}, ${place[4]}, ${place[5]}, ${place[6]}, '${place[7]}'], null, null, DPR1_send_mod.eventSend(event, 1))`,
-            titleStr: `Open same section in ${DPR_G.G_hTitles[ht]} side by side. Shift+click to open in same pane.`,
+            titleStr: null,
             visibleStr: 'true',
           };
         } else if (relhere.split('#')[hic] != '') {


### PR DESCRIPTION
Previously, when hovering over the `m`, `a`, or `t` button, the tooltip did NOT display the relevant keyboard shortcuts if that text was already being viewed in the main pane (see https://github.com/digitalpalireader/digitalpalireader/commit/ceb6cd50ea57a05b182bf87a59d6bc01e0fb4ce5?w=1#diff-abbe7d90697ecc929ed9134c789ad63511d74572e737c5a52175965abc7aaa72L229-R230). This led to different tooltips depending on which text was being viewed in the main pane. This PR standardizes the tooltips for these three buttons by removing an existing `titleStr` override. As a result, each tooltip will now display the relevant keyboard shortcuts.

## Before
![before](https://user-images.githubusercontent.com/5777094/111392825-c21b1e80-868d-11eb-87e6-3f28c2ce229c.gif)

## After
![after](https://user-images.githubusercontent.com/5777094/111392821-c0e9f180-868d-11eb-96bc-3f007ba70fc0.gif)

