### PR TITLE
fix: allow ped definition to scroll independently of word breakdown

### DIFF
--- a/_dprhtml/css/styles.css
+++ b/_dprhtml/css/styles.css
@@ -612,6 +612,7 @@ font-size:14px;
 }
 
 #bottom {
+  overflow-y: auto;
   position: relative;
 }
 


### PR DESCRIPTION
This PR allows the PED definition section in the bottom pane to scroll independently of the word breakdown section.

## Before
![before](https://user-images.githubusercontent.com/5777094/111395061-5a1b0700-8692-11eb-8172-3243af5119e8.gif)

## After
![after](https://user-images.githubusercontent.com/5777094/111395069-5d15f780-8692-11eb-95c3-d1b944dafbfd.gif)

Closes #323.