### PR TITLE
fix: show definition in bottom pane when dppn link is clicked

### DIFF
--- a/_dprhtml/features/bottom-pane/init.js
+++ b/_dprhtml/features/bottom-pane/init.js
@@ -1,6 +1,14 @@
 'use strict';
 
 class BottomPaneTabsViewModel {
+  static TabNumber = {
+    DICTIONARY: 1,
+    CONVERSION: 2,
+    TEXTPAD: 3,
+    TRANSLATION: 4,
+    CONJUGATION: 5,
+  };
+
   constructor() {
     this.isDTabSelected = ko.observable(true);
     this.isCvTabSelected = ko.observable(false);

--- a/_dprhtml/features/bottom-pane/init.js
+++ b/_dprhtml/features/bottom-pane/init.js
@@ -1,14 +1,6 @@
 'use strict';
 
 class BottomPaneTabsViewModel {
-  static TabNumber = {
-    DICTIONARY: 1,
-    CONVERSION: 2,
-    TEXTPAD: 3,
-    TRANSLATION: 4,
-    CONJUGATION: 5,
-  };
-
   constructor() {
     this.isDTabSelected = ko.observable(true);
     this.isCvTabSelected = ko.observable(false);

--- a/_dprhtml/js/dict_xml.js
+++ b/_dprhtml/js/dict_xml.js
@@ -680,7 +680,7 @@ function displayDictData(data) {
   }
 
   if (DPR_PAL.isNavigationFeature()) {
-    __otherDialogsViewModel.showBottomPane(BottomPaneTabsViewModel.TabNumber.DICTIONARY);
+    DPR1_chrome_mod.DPRShowBottomPane();
   }
 }
 

--- a/_dprhtml/js/dict_xml.js
+++ b/_dprhtml/js/dict_xml.js
@@ -678,6 +678,10 @@ function displayDictData(data) {
     $(difbId).append(dataNode);
     $('#paliTextContent').scrollTop(0);
   }
+
+  if (DPR_PAL.isNavigationFeature()) {
+    __otherDialogsViewModel.showBottomPane(BottomPaneTabsViewModel.TabNumber.DICTIONARY);
+  }
 }
 
 return {

--- a/_dprhtml/js/dpr_pal.js
+++ b/_dprhtml/js/dpr_pal.js
@@ -125,7 +125,7 @@
       });
   }
 
-  DPR_PAL.getDifId = () => /analysis=[^&]/.test(window.location.href) ? 'difb-bottom' : 'difb';
+  DPR_PAL.getDifId = () => DPR_PAL.isNavigationFeature() ? 'difb-bottom' : 'difb';
 
    // NOTE: Keep DPR-main after DPRm, as was the order in palemoon.
   DPR_PAL.DPR_tabs = Object.freeze({


### PR DESCRIPTION
While debugging #280, I found two problems (both of which this PR addresses) that would prevent a DPPN definition from showing up:
- Clicking a DPPN link will not open the bottom pane if it is not already open
- Clicking a DPPN link doesn't work when the url path does not include an `analysis` parameter

Closes #280.