### PR TITLE
fix: show analysis and bottom pane when using search feature

### DIFF
--- a/_dprhtml/js/dict_xml.js
+++ b/_dprhtml/js/dict_xml.js
@@ -679,7 +679,7 @@ function displayDictData(data) {
     $('#paliTextContent').scrollTop(0);
   }
 
-  if (DPR_PAL.isNavigationFeature()) {
+  if (!DPR_PAL.isDictionaryFeature()) {
     DPR1_chrome_mod.DPRShowBottomPane();
   }
 }

--- a/_dprhtml/js/dpr_pal.js
+++ b/_dprhtml/js/dpr_pal.js
@@ -125,7 +125,7 @@
       });
   }
 
-  DPR_PAL.getDifId = () => DPR_PAL.isNavigationFeature() ? 'difb-bottom' : 'difb';
+  DPR_PAL.getDifId = () => DPR_PAL.isDictionaryFeature() ? 'difb' : 'difb-bottom';
 
    // NOTE: Keep DPR-main after DPRm, as was the order in palemoon.
   DPR_PAL.DPR_tabs = Object.freeze({


### PR DESCRIPTION
Issue #332 reveals a bug whereby the analysis would not appear in the bottom pane when using the search feature. This PR corrects that problem.