### PR TITLE
fix: update keyboard shortcut for reset settings in help modal

### DIFF
--- a/_dprhtml/index.html
+++ b/_dprhtml/index.html
@@ -458,7 +458,7 @@
               <!-- <tr><td>,</td><td>&nbsp;Display previous PED or DPPN entry</td></tr>
               <tr><td>.</td><td>&nbsp;Display next PED or DPPN entry</td></tr> -->
               <tr><td>%</td><td>&nbsp;Display DPR settings</td></tr>
-              <tr><td>r</td><td>&nbsp;Reset all DPR settings</td></tr>
+              <tr><td>R</td><td>&nbsp;Reset all DPR settings</td></tr>
               <tr><td>*</td><td>&nbsp;Display Pali quote</td></tr>
               <tr><td>` or &amp;</td><td>&nbsp;Toggle sidebar</td></tr>
               <!-- <tr><td>b</td><td>&nbsp;Save bookmark</td></tr> -->


### PR DESCRIPTION
This is a follow-up of #340. When updating the keyboard shortcut, I forgot to update the keyboard shortcut in the help modal.