### PR TITLE
refactor: extract cped analysis output logic into cped module

### DIFF
--- a/_dprhtml/index.html
+++ b/_dprhtml/index.html
@@ -531,6 +531,7 @@
     <script src="/_dprhtml/js/analysis_arrays.js"></script>
     <script src="/_dprhtml/js/analysis_function.js"></script>
     <script src="/_dprhtml/js/analysis_output.js"></script>
+    <script src="/_dprhtml/js/cped.js"></script>
     <script src="/_dprhtml/js/inflect.js"></script>
     <script src="/_dprhtml/js/grammar.js"></script>
     <script src="/_dprhtml/js/bv.js"></script>

--- a/_dprhtml/js/analysis_output.js
+++ b/_dprhtml/js/analysis_output.js
@@ -122,7 +122,7 @@ async function outputDef(sectionId,which,first,frombox)
 
   var myConj = owparts[owparts.length-1].split('#')[0].split('^');
   if(myConj[3]) { // if root form is found, set up conjugation
-    if(DPR_cped_mod.getInflectionGroup(myConj[3]) != 'I') {
+    if(CPED.getInflectionGroup(myConj[3]) != 'I') {
       conjWord.form = DPR_translit_mod.toUni(DPR_G.G_outwords[which][0].split('-').pop());
       conjWord.root = DPR_translit_mod.toUni(myConj[3]);
     }
@@ -218,15 +218,15 @@ async function outputDef(sectionId,which,first,frombox)
     {
       if (thisconcise[x].length == 0) { continue; }
 
-      let condefnotype = DPR_cped_mod.getDefinition(thisconcise[x]);
+      let condefnotype = CPED.getDefinition(thisconcise[x]);
       if (condefnotype.length > 100) {
           condefnotype = condefnotype.substring(0,100);
         condefnotype += '...'
       }
 
-      let concisedef = DPR_cped_mod.getDefinition(thisconcise[x]);
+      let concisedef = CPED.getDefinition(thisconcise[x]);
 
-      let grammar = DPR_cped_mod.getGrammar(thisconcise[x]);
+      let grammar = CPED.getGrammar(thisconcise[x]);
       if(/ of /.test(grammar)) {
         var base = / of ([^;,. ]+)/.exec(grammar)[1];
         grammar = grammar.replace(base, await DPR1_format_mod.linkToPED(base,base));

--- a/_dprhtml/js/analysis_output.js
+++ b/_dprhtml/js/analysis_output.js
@@ -122,7 +122,7 @@ async function outputDef(sectionId,which,first,frombox)
 
   var myConj = owparts[owparts.length-1].split('#')[0].split('^');
   if(myConj[3]) { // if root form is found, set up conjugation
-    if(DPR_G.yt[myConj[3]][4] != 'I') {
+    if(DPR_cped_mod.getInflectionGroup(myConj[3]) != 'I') {
       conjWord.form = DPR_translit_mod.toUni(DPR_G.G_outwords[which][0].split('-').pop());
       conjWord.root = DPR_translit_mod.toUni(myConj[3]);
     }
@@ -218,22 +218,21 @@ async function outputDef(sectionId,which,first,frombox)
     {
       if (thisconcise[x].length == 0) { continue; }
 
-      var concisedefa = DPR_G.yt[thisconcise[x]];
-
-      var condefnotype = concisedefa[2];
+      let condefnotype = DPR_cped_mod.getDefinition(thisconcise[x]);
       if (condefnotype.length > 100) {
           condefnotype = condefnotype.substring(0,100);
         condefnotype += '...'
       }
 
-      var concisedef = concisedefa[2];
+      let concisedef = DPR_cped_mod.getDefinition(thisconcise[x]);
 
-      if(/ of /.test(concisedefa[1])) {
-        var base = / of ([^;,. ]+)/.exec(concisedefa[1])[1];
-        concisedefa[1] = concisedefa[1].replace(base, await DPR1_format_mod.linkToPED(base,base));
+      let grammar = DPR_cped_mod.getGrammar(thisconcise[x]);
+      if(/ of /.test(grammar)) {
+        var base = / of ([^;,. ]+)/.exec(grammar)[1];
+        grammar = grammar.replace(base, await DPR1_format_mod.linkToPED(base,base));
       }
 
-      concisedef = DPR_translit_mod.toUni(concisedef + ' (' + concisedefa[1] + ')');
+      concisedef = DPR_translit_mod.toUni(concisedef + ' (' + grammar + ')');
 
       var conciseword = thisconcise[x];
       conciseword = DPR_translit_mod.toUni(conciseword);

--- a/_dprhtml/js/cped.js
+++ b/_dprhtml/js/cped.js
@@ -6,7 +6,7 @@ const getCPEDEntryAsObject = (velthiusWord) => {
   return { grammar, definition, inflectionGroup };
 };
 
-const DPR_cped_mod = {
+const CPED = {
   getDefinition(velthiusWord) {
     return getCPEDEntryAsObject(velthiusWord).definition;
   },
@@ -19,5 +19,5 @@ const DPR_cped_mod = {
 };
 
 if (typeof module !== "undefined") {
-  module.exports = DPR_cped_mod;
+  module.exports = CPED;
 }

--- a/_dprhtml/js/cped.js
+++ b/_dprhtml/js/cped.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const getCPEDEntryAsObject = (velthiusWord) => {
+  const entry = DPR_G.yt[velthiusWord] || [];
+  const [, grammar, definition, , inflectionGroup] = entry;
+  return { grammar, definition, inflectionGroup };
+};
+
+const DPR_cped_mod = {
+  getDefinition(velthiusWord) {
+    return getCPEDEntryAsObject(velthiusWord).definition;
+  },
+  getGrammar(velthiusWord) {
+    return getCPEDEntryAsObject(velthiusWord).grammar;
+  },
+  getInflectionGroup(velthiusWord) {
+    return getCPEDEntryAsObject(velthiusWord).inflectionGroup;
+  },
+};
+
+if (typeof module !== "undefined") {
+  module.exports = DPR_cped_mod;
+}

--- a/_dprhtml/js/cped.test.js
+++ b/_dprhtml/js/cped.test.js
@@ -1,0 +1,30 @@
+import "../../en/cped";
+
+import { getDefinition, getGrammar, getInflectionGroup } from "./cped";
+
+describe("getDefinition", () => {
+  test.each([
+    ["bhikkhu", "a Buddhist monk."],
+    ["ambala.t.thikaa", "a mango plant."],
+  ])("%s => %s", (velthiusWord, definition) => {
+    expect(getDefinition(velthiusWord)).toBe(definition);
+  });
+});
+
+describe("getGrammar", () => {
+  test.each([
+    ["bhikkhu", "m."],
+    ["ambala.t.thikaa", "f."],
+  ])("%s => %s", (velthiusWord, grammar) => {
+    expect(getGrammar(velthiusWord)).toBe(grammar);
+  });
+});
+
+describe("getInflectionGroup", () => {
+  test.each([
+    ["bhikkhu", "N"],
+    ["bhiyyo", "I"],
+  ])("%s => %s", (velthiusWord, inflectionGroup) => {
+    expect(getInflectionGroup(velthiusWord)).toBe(inflectionGroup);
+  });
+});

--- a/_dprhtml/js/translit.js
+++ b/_dprhtml/js/translit.js
@@ -141,3 +141,7 @@ return {
   getConvertLangId: getConvertLangId,
 }
 })()
+
+if (typeof module !== "undefined") {
+  module.exports = DPR_translit_mod;
+}

--- a/_dprhtml/js/translitCore.js
+++ b/_dprhtml/js/translitCore.js
@@ -626,3 +626,7 @@ return {
   ScriptIds: Script,
 }
 })()
+
+if (typeof module !== "undefined") {
+  module.exports = DPR_translitCore_mod;
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  coveragePathIgnorePatterns: ["<rootDir>/en/cped/index.js"],
   roots: ["_dprhtml/"],
   setupFilesAfterEnv: ["./jest.setup.js"],
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -8,3 +8,5 @@ window.ko = knockout;
 window.DPR_G = require('./_dprhtml/js/globalObject');
 window.DPR_PAL = require('./_dprhtml/js/dpr_pal');
 window.DPR_prefload_mod = require('./_dprhtml/js/prefload');
+window.DPR_translitCore_mod = require('./_dprhtml/js/translitCore');
+window.DPR_translit_mod = require('./_dprhtml/js/translit');


### PR DESCRIPTION
This PR creates a new module (`CPED`) to capture a subset of the logic surrounding CPED lookup. In particular, the module will evolve as a high-level API used to access data in the CPED. Eventually, an identical (or similar) module will be written for the DPD, allowing us to completely replace the CPED.

For this PR, I have identified all references to `DPR_G.yt` (the CPED lookup table) in `analysis_output.js` and created helper methods in the new CPED module. It is a small but tangible step towards #321.