### PR TITLE
fix: documentation updates

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,8 +1,8 @@
 # Configuration file for the Sphinx documentation builder.
 # See: https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-author = 'Sirimangalo International'
-copyright = '2021, Sirimangalo International'
+author = 'Digital Pāli Tools'
+copyright = '2021, <a href="https://d.pali.tools/">Digital Pāli Tools</a>'
 project = 'Digital Pāli Reader'
 release = '0.0.0'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,7 +2,7 @@
 # See: https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 author = 'Digital Pāli Tools'
-copyright = '2021, <a href="https://d.pali.tools/">Digital Pāli Tools</a>'
+copyright = '<a href="https://d.pali.tools/">Digital Pāli Tools</a>'
 project = 'Digital Pāli Reader'
 release = '0.0.0'
 

--- a/docs/pages/welcome-to-dpr.rst
+++ b/docs/pages/welcome-to-dpr.rst
@@ -875,15 +875,15 @@ distributed freely. May all be happy and well.
 Final Words
 -----------
 
-1. Please write to me any errors you may find, big or small. My email is
-   yuttadhammo@gmail.com .
+1. Digital Pāli Reader was originally created by Yuttadhammo Bhikkhu
+   (yuttadhammo@gmail.com).
 
-2. Please check the `DPR Homepage <http://pali.sirimangalo.org/>`__ for
+2. Please check the `DPR Homepage <http://d.pali.tools/>`__ for
    updates.
 
-3. Please visit the `DPR Forum <http://pali.sirimangalo.org/forum/>`__
+3. Please visit the `DPR Forum <https://discord.gg/qdUNgr57wg>`__
    to ask questions about the DPR and the Pali language in general.
 
 Best wishes and good luck,
 
-Yuttadhammo
+Digital Pāli Tools team


### PR DESCRIPTION
- Remove copyright year and update display name to `Digital Pāli Tools`
- Link copyright text to DPT
- Update "Final Words" copy and add links to DPT site and Discord invite